### PR TITLE
WIP: Allow setting key/value in a metadata stored in the topology

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -285,6 +285,9 @@ func ExtractSetValues(sql string) (keyValues map[SetKey]interface{}, scope strin
 		case strings.HasPrefix(key, "@@session."):
 			scope = SessionStr
 			key = strings.TrimPrefix(key, "@@session.")
+		case strings.HasPrefix(key, "@@vitess_metadata."):
+			scope = VitessMetadataStr
+			key = strings.TrimPrefix(key, "@@vitess_metadata.")
 		case strings.HasPrefix(key, "@@"):
 			key = strings.TrimPrefix(key, "@@")
 		}

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -662,9 +662,10 @@ type Set struct {
 
 // Set.Scope or Show.Scope
 const (
-	SessionStr  = "session"
-	GlobalStr   = "global"
-	ImplicitStr = ""
+	SessionStr        = "session"
+	GlobalStr         = "global"
+	VitessMetadataStr = "vitess_metadata"
+	ImplicitStr       = ""
 )
 
 // Format formats the node.

--- a/go/vt/topo/events/metadata_change.go
+++ b/go/vt/topo/events/metadata_change.go
@@ -1,0 +1,8 @@
+package events
+
+// MetadataChange is an event that describes changes to topology metadata
+type MetadataChange struct {
+	KeyspaceName string
+	Key          string
+	Status       string
+}

--- a/go/vt/topo/metadata.go
+++ b/go/vt/topo/metadata.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import (
+	"context"
+	"path"
+
+	"vitess.io/vitess/go/event"
+	"vitess.io/vitess/go/vt/topo/events"
+)
+
+// UpsertMetadata sets the key/value in the metadata if it doesn't exist, otherwise it updates the content
+func (ts *Server) UpsertMetadata(ctx context.Context, keyspace string, key string, val string) error {
+	keyPath := path.Join(MetadataPath, keyspace, key)
+	_, version, err := ts.globalCell.Get(ctx, keyPath)
+	if err != nil && IsErrType(err, NoNode) {
+		return create(ctx, ts, keyspace, keyPath, val)
+	}
+
+	return update(ctx, ts, keyspace, keyPath, val, version)
+}
+
+// GetMetadata retrieves the metadata value for the given key
+func (ts *Server) GetMetadata(ctx context.Context, keyspace string, key string) (string, error) {
+	keyPath := path.Join(MetadataPath, keyspace, key)
+	contents, _, err := ts.globalCell.Get(ctx, keyPath)
+	if err != nil {
+		return "", err
+	}
+
+	return string(contents), nil
+}
+
+func create(ctx context.Context, ts *Server, keyspace string, path string, val string) error {
+	if _, err := ts.globalCell.Create(ctx, path, []byte(val)); err != nil {
+		return err
+	}
+
+	dispatchEvent(keyspace, path, "created")
+	return nil
+}
+
+func update(ctx context.Context, ts *Server, keyspace string, path string, val string, version Version) error {
+	if _, err := ts.globalCell.Update(ctx, path, []byte(val), version); err != nil {
+		return err
+	}
+
+	dispatchEvent(keyspace, path, "updated")
+	return nil
+}
+
+func dispatchEvent(keyspace string, key string, status string) {
+	event.Dispatch(&events.MetadataChange{
+		KeyspaceName: keyspace,
+		Key:          key,
+		Status:       status,
+	})
+}

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -84,6 +84,7 @@ const (
 	KeyspacesPath    = "keyspaces"
 	ShardsPath       = "shards"
 	TabletsPath      = "tablets"
+	MetadataPath     = "vitess_metadata"
 )
 
 // Factory is a factory interface to create Conn objects.


### PR DESCRIPTION
This is a work in progress to explore how we can provide a flexible key/value metadata in the topology service. Particularly this will allow us to store keyspace specific data like vschema migrations, etc.

This PR uses the "SET" statement and a customer scope "vitess_metadata" to set desired values. Separate PR will address the read side

Alternative options could use its own SQL, like "ALTER VSCHEMA" to modify the metadata.
ALTER VMETADATA SET vschema_migrations WITH version=003, author=kalfonso
SHOW VMETADATA # on the read side

Signed-off-by: Karel Alfonso Sague <kalfonso@squareup.com>